### PR TITLE
Switch to shapeless 2.2 final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.12.3",
-  "com.chuusai" %% "shapeless" % "2.2.0-RC6"
+  "com.chuusai" %% "shapeless" % "2.2.0"
 )
 
 libraryDependencies ++= {


### PR DESCRIPTION
On hold: orphan derivation (conflicts with cached implicits)