### PR TITLE
Switch to shapeless-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,6 @@ lazy val scalacheckShapeless = crossProject.in(file("."))
   .settings(commonSettings: _*)
   .settings(compileSettings: _*)
   .settings(publishSettings: _*)
-  .settings(releaseSettings: _*)
-  .settings(extraReleaseSettings: _*)
   .settings(mimaSettings: _*)
   .jsSettings(scalaJSStage in Test := FastOptStage)
 
@@ -91,11 +89,6 @@ lazy val noPublishSettings = Seq(
   publish := (),
   publishLocal := (),
   publishArtifact := false
-)
-
-lazy val extraReleaseSettings = Seq(
-  ReleaseKeys.versionBump := sbtrelease.Version.Bump.Bugfix,
-  sbtrelease.ReleasePlugin.ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value
 )
 
 lazy val mimaSettings =

--- a/build.sbt
+++ b/build.sbt
@@ -38,9 +38,8 @@ lazy val compileSettings = Seq(
   ),
   libraryDependencies ++= Seq(
     "org.scalacheck" %%% "scalacheck" % "1.13.0-bceacad-SNAPSHOT",
-    "com.chuusai" %%% "shapeless" % "2.3.0-SNAPSHOT",
-    "com.github.alexarchambault" %%% "derive" % "0.1.0-SNAPSHOT",
-    "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
+    "com.chuusai" %%% "shapeless" % "2.2.5",
+    "com.github.alexarchambault" %%% "shapeless-compat" % "1.0.0-M1"
   ),
   libraryDependencies ++= {
     if (scalaVersion.value.startsWith("2.10."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,3 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")
-
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")

--- a/shared/src/main/scala/org/scalacheck/Shapeless.scala
+++ b/shared/src/main/scala/org/scalacheck/Shapeless.scala
@@ -1,7 +1,7 @@
 package org.scalacheck
 
-import shapeless._
-import _root_.derive.LowPriority
+import shapeless.{ Lazy => _, _ }
+import shapeless.compat._
 
 import derive._
 import util._
@@ -80,30 +80,24 @@ trait DerivedInstances {
 
   implicit def mkArbitrary[T]
    (implicit
-     priority: Cached[Strict[LowPriority[
-       Arbitrary[T],
-       MkArbitrary[T]
-     ]]]
+     ev: Strict[LowPriority[Arbitrary[T]]],
+     priority: Strict[MkArbitrary[T]]
    ): Arbitrary[T] =
-    priority.value.value.value.arbitrary
+    priority.value.arbitrary
 
   implicit def mkShrink[T]
    (implicit
-     priority: Cached[Strict[LowPriority[
-       Mask[Witness.`"Shrink.shrinkAny"`.T, Shrink[T]],
-       MkShrink[T]
-     ]]]
+     ev: Strict[LowPriority[Ignoring[Witness.`"Shrink.shrinkAny"`.T, Shrink[T]]]],
+     priority: Strict[MkShrink[T]]
    ): Shrink[T] =
-    priority.value.value.value.shrink
+    priority.value.shrink
 
   implicit def mkCogen[T]
    (implicit
-     priority: Cached[Strict[LowPriority[
-       Cogen[T],
-       MkCogen[T]
-     ]]]
+     ev: Strict[LowPriority[Cogen[T]]],
+     priority: Strict[MkCogen[T]]
    ): Cogen[T] =
-    priority.value.value.value.cogen
+    priority.value.cogen
 
 }
 

--- a/shared/src/main/scala/org/scalacheck/Singletons.scala
+++ b/shared/src/main/scala/org/scalacheck/Singletons.scala
@@ -1,6 +1,7 @@
 package org.scalacheck
 
-import shapeless._
+import shapeless.{ Lazy => _, _ }
+import shapeless.compat._
 
 /**
  * Type class providing the instances of `T` that can be built out of

--- a/shared/src/main/scala/org/scalacheck/derive/MkArbitrary.scala
+++ b/shared/src/main/scala/org/scalacheck/derive/MkArbitrary.scala
@@ -1,7 +1,8 @@
 package org.scalacheck
 package derive
 
-import shapeless._
+import shapeless.{ Lazy => _, _ }
+import shapeless.compat._
 
 
 /**

--- a/shared/src/main/scala/org/scalacheck/derive/MkCogen.scala
+++ b/shared/src/main/scala/org/scalacheck/derive/MkCogen.scala
@@ -2,7 +2,9 @@ package org.scalacheck
 package derive
 
 import org.scalacheck.rng.Seed
-import shapeless._
+import shapeless.compat._
+
+import shapeless.{ Lazy => _, _ }
 
 /**
  * Derives `Cogen[T]` instances for `T` an `HList`, a `Coproduct`,

--- a/shared/src/test/scala/org/scalacheck/ArbitraryTests.scala
+++ b/shared/src/test/scala/org/scalacheck/ArbitraryTests.scala
@@ -1,10 +1,11 @@
 package org.scalacheck
 
 import org.scalacheck.Gen.Parameters
-import org.scalacheck.derive.{MkCoproductArbitrary, MkHListArbitrary, MkArbitrary}
+import org.scalacheck.derive._
 import org.scalacheck.rng.Seed
 
-import shapeless._
+import shapeless.{ Lazy => _, _ }
+import shapeless.compat._
 import shapeless.test.illTyped
 
 import utest._

--- a/shared/src/test/scala/org/scalacheck/CogenTests.scala
+++ b/shared/src/test/scala/org/scalacheck/CogenTests.scala
@@ -1,9 +1,10 @@
 package org.scalacheck
 
 import org.scalacheck.TestsDefinitions._
-import org.scalacheck.derive.{MkCoproductCogen, MkHListCogen, MkCogen}
+import org.scalacheck.derive._
 import org.scalacheck.rng.Seed
-import shapeless._
+import shapeless.{ Lazy => _, _ }
+import shapeless.compat._
 import utest._
 
 object CogenTests extends TestSuite {

--- a/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
+++ b/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
@@ -1,7 +1,8 @@
 package org.scalacheck
 
-import org.scalacheck.derive.{MkCoproductShrink, MkHListShrink, MkShrink}
-import shapeless._
+import org.scalacheck.derive._
+import shapeless.{ Lazy => _, _ }
+import shapeless.compat._
 import utest._
 import Util._
 

--- a/shared/src/test/scala/org/scalacheck/SingletonsTests.scala
+++ b/shared/src/test/scala/org/scalacheck/SingletonsTests.scala
@@ -1,6 +1,7 @@
 package org.scalacheck
 
-import shapeless._
+import shapeless.{ Lazy => _, _ }
+import shapeless.compat._
 import utest._
 
 object SingletonsTestsDefinitions {


### PR DESCRIPTION
Temporary lib (https://github.com/alexarchambault/shapeless-compat), so that we can depend on shapeless 2.2 here.