### PR TITLE
Rename org.scalacheck.Shapeless to org.scalacheck.ScalacheckShapeless

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ using shapeless 2.2 along with scalacheck 1.12, see the
 
 
 
-Import the content of `org.scalacheck.Shapeless` close to where you want
+Import the content of `org.scalacheck.ScalacheckShapeless` close to where you want
 `Arbitrary` type classes to be automatically available for case classes
 / sealed hierarchies,
 ```scala
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 
 //  If you defined:
 

--- a/core/shared/src/main/scala/org/scalacheck/ScalacheckShapeless.scala
+++ b/core/shared/src/main/scala/org/scalacheck/ScalacheckShapeless.scala
@@ -2,10 +2,15 @@ package org.scalacheck
 
 import derive._
 
-object Shapeless
+trait ScalacheckShapeless
   extends SingletonInstances
   with HListInstances
   with CoproductInstances
   with DerivedInstances
   with FieldTypeInstances
   with EnumerationInstances
+
+object ScalacheckShapeless extends ScalacheckShapeless
+
+@deprecated("Use ScalacheckShapeless instead", "1.1.6")
+object Shapeless extends ScalacheckShapeless

--- a/test/shared/src/test/scala/org/scalacheck/ArbitraryTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/ArbitraryTests.scala
@@ -14,7 +14,7 @@ import Util._
 
 object ArbitraryTests extends TestSuite {
   import TestsDefinitions._
-  import Shapeless._
+  import ScalacheckShapeless._
 
 
   lazy val expectedSimpleArb =
@@ -193,7 +193,7 @@ object ArbitraryTests extends TestSuite {
       MkHListArbitrary.hcons(
         Arbitrary.arbInt,
         MkHListArbitrary.hcons(
-          Shapeless.arbitrarySingletonType[Witness.`"aa"`.T],
+          ScalacheckShapeless.arbitrarySingletonType[Witness.`"aa"`.T],
           MkHListArbitrary.hnil,
           ops.hlist.Length[HNil],
           ops.nat.ToInt[Nat._0]
@@ -207,7 +207,7 @@ object ArbitraryTests extends TestSuite {
     MkArbitrary.genericProduct(
       Generic[BaseWithSingleton.Main],
       MkHListArbitrary.hcons(
-        Shapeless.arbitrarySingletonType[Witness.`"aa"`.T],
+        ScalacheckShapeless.arbitrarySingletonType[Witness.`"aa"`.T],
         MkHListArbitrary.hnil,
         ops.hlist.Length[HNil],
         ops.nat.ToInt[Nat._0]

--- a/test/shared/src/test/scala/org/scalacheck/CogenTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/CogenTests.scala
@@ -13,7 +13,7 @@ import Util._
 
 object CogenTests extends TestSuite {
   import TestsDefinitions._
-  import Shapeless._
+  import ScalacheckShapeless._
 
   lazy val expectedIntStringBoolCogen =
     expectedIntStringBoolMkHListCogen.cogen

--- a/test/shared/src/test/scala/org/scalacheck/PropTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/PropTests.scala
@@ -2,7 +2,7 @@ package org.scalacheck
 
 import utest._
 import Util._
-import Shapeless._
+import ScalacheckShapeless._
 import org.scalacheck.TestsDefinitions.{T1, T1NoRecursiveTC}
 
 object PropTests extends TestSuite {

--- a/test/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
@@ -1,6 +1,6 @@
 package org.scalacheck
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.derive._
 import shapeless._
 import shapeless.labelled._

--- a/test/shared/src/test/scala/org/scalacheck/SizeTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/SizeTests.scala
@@ -5,7 +5,7 @@ import utest._
 import org.scalacheck.rng.Seed
 
 object SizeTests0 {
-  import org.scalacheck.Shapeless._
+  import org.scalacheck.ScalacheckShapeless._
 
   import SizeTestsDefinitions._
 


### PR DESCRIPTION
Plus make it a trait that can be extended by other libs, a bit like https://github.com/alexarchambault/argonaut-shapeless/pull/90.