### PR TITLE
Update Scala import in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Import the content of `org.scalacheck.ScalacheckShapeless` close to where you wa
 `Arbitrary` type classes to be automatically available for case classes
 / sealed hierarchies,
 ```scala
-import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.Shapeless._
 
 //  If you defined:
 


### PR DESCRIPTION
I am using this version: "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.5"

I had to import the library using: `import org.scalacheck.Shapeless._`