### PR TITLE
Made generic Cogen implementations 'lazier'

### DIFF
--- a/core/shared/src/main/scala/org/scalacheck/derive/MkCogen.scala
+++ b/core/shared/src/main/scala/org/scalacheck/derive/MkCogen.scala
@@ -31,15 +31,17 @@ object MkCogen {
    (implicit
      gen: Generic.Aux[P, L],
      cogen: Lazy[MkHListCogen[L]]
-   ): MkCogen[P] =
-    instance(cogen.value.cogen.contramap(gen.to))
+   ): MkCogen[P] = instance(Cogen { (seed: Seed, p: P) =>
+     cogen.value.cogen.perturb(seed, gen.to(p))
+   })
 
   implicit def genericCoproduct[S, C <: Coproduct]
    (implicit
      gen: Generic.Aux[S, C],
      cogen: Lazy[MkCoproductCogen[C]]
-   ): MkCogen[S] =
-    instance(cogen.value.cogen.contramap(gen.to))
+   ): MkCogen[S] = instance(Cogen { (seed: Seed, s: S) =>
+     cogen.value.cogen.perturb(seed, gen.to(s))
+   })
 }
 
 trait MkHListCogen[L <: HList] {

--- a/test/shared/src/test/scala/org/scalacheck/CogenTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/CogenTests.scala
@@ -65,6 +65,29 @@ object CogenTests extends TestSuite {
       )
     ).cogen
 
+  lazy val expectedTree1Cogen: Cogen[T1.Tree] =
+    MkCogen.genericCoproduct(
+      Generic[T1.Tree],
+      Lazy(MkCoproductCogen.ccons(
+        MkCogen.genericProduct(
+          Generic[T1.Leaf.type],
+          Lazy(MkHListCogen.hnil)
+        ).cogen,
+        MkCoproductCogen.ccons(
+          MkCogen.genericProduct(
+            Generic[T1.Node],
+            Lazy(MkHListCogen.hcons(
+              expectedTree1Cogen,
+              MkHListCogen.hcons(
+                expectedTree1Cogen,
+                MkHListCogen.hcons(
+                  Cogen.cogenInt,
+                  MkHListCogen.hnil
+                ))))
+          ).cogen,
+          MkCoproductCogen.cnil
+        )))
+    ).cogen
 
   val tests = TestSuite {
 
@@ -142,6 +165,10 @@ object CogenTests extends TestSuite {
       compareCogen(expectedUnionCogen, cogen)
     }
 
+    'tree1 - {
+      val cogen = Cogen[T1.Tree]
+      compareCogen(expectedTree1Cogen, cogen)
+    }
   }
 
 }


### PR DESCRIPTION
The old implementation relied on `Cogen.contramap`. Although convenient, it would force evaluation of the `Lazy` value too early and cause a stack overflow for recursive types like `T1.Tree`. The new implementation is equivalent except that evaluation is forced on call to `perturb` instead of on instance creation.