### PR TITLE
Modified MkCoproductSchrink to stop at any singleton

### DIFF
--- a/core/shared/src/main/scala/org/scalacheck/derive/MkShrink.scala
+++ b/core/shared/src/main/scala/org/scalacheck/derive/MkShrink.scala
@@ -107,9 +107,11 @@ object MkCoproductShrink {
     instance(
       Shrink {
         case Inl(h) =>
-          tailSingletons.value().toStream.map(Inr(_)) ++ headShrink.value.shrink(h).map(Inl(_))
+          if (headSingletons.value().contains(h)) Stream.empty
+          else tailSingletons.value().toStream.map(Inr(_)) ++ headShrink.value.shrink(h).map(Inl(_))
         case Inr(t) =>
-          headSingletons.value().toStream.map(Inl(_)) ++ tailShrink.shrink.shrink(t).map(Inr(_))
+          if (tailSingletons.value().contains(t)) Stream.empty
+          else headSingletons.value().toStream.map(Inl(_)) ++ tailShrink.shrink.shrink(t).map(Inr(_))
       }
     )
 }

--- a/core/shared/src/main/scala/org/scalacheck/derive/Singletons.scala
+++ b/core/shared/src/main/scala/org/scalacheck/derive/Singletons.scala
@@ -88,7 +88,8 @@ object HListSingletons {
   implicit val hnil: HListSingletons[HNil] =
     instance(Seq(HNil))
 
-  implicit def hconsFound[H, T <: HList]
+  @deprecated("Kept for binary compatibility", "1.1.7")
+  def hconsFound[H, T <: HList]
    (implicit
      headSingletons: Strict[Singletons[H]],
      tailSingletons: HListSingletons[T]

--- a/test/shared/src/main/scala/org/scalacheck/TestsDefinitions.scala
+++ b/test/shared/src/main/scala/org/scalacheck/TestsDefinitions.scala
@@ -2,7 +2,7 @@ package org.scalacheck
 
 import org.scalacheck.derive.Recursive
 
-import shapeless.{ Lazy => _, _ }
+import shapeless._
 import shapeless.record._
 import shapeless.union._
 
@@ -87,4 +87,7 @@ object TestsDefinitions {
     case class BaseNoArbN(n: NoArbitraryType) extends BaseNoArb
   }
 
+  sealed trait Maybe
+  case object Yes extends Maybe
+  case object No extends Maybe
 }

--- a/test/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
@@ -120,6 +120,48 @@ object ShrinkTests extends TestSuite {
       compareShrink(shrink, expectedUnionShrink)
     }
 
+    'adt - {
+      val shrink = implicitly[Shrink[A]]
+
+      'caseClass - {
+        * - {
+          val res = shrink.shrink(B(2, "b")).toVector
+          assert(res.contains(C))
+          assert(res.contains(F))
+          assert(res.contains(Baz))
+        }
+
+        * - {
+          val res = shrink.shrink(E(1.3, Some(1.2f))).toVector
+          assert(res.contains(C))
+          assert(res.contains(F))
+          assert(res.contains(Baz))
+        }
+      }
+
+      'caseObject - {
+        * - {
+          val res = shrink.shrink(C).toVector
+          assert(res.isEmpty)
+        }
+
+        * - {
+          val res = shrink.shrink(F).toVector
+          assert(res.isEmpty)
+        }
+
+        * - {
+          val res = shrink.shrink(Baz).toVector
+          assert(res.isEmpty)
+        }
+      }
+    }
+
+    'maybe {
+      val shrink = implicitly[Shrink[Maybe]]
+      assert(shrink.shrink(Yes).isEmpty)
+      assert(shrink.shrink(No).isEmpty)
+    }
   }
 
 }


### PR DESCRIPTION
Consider an ADT with at least 2 singletons:
```scala
sealed trait Maybe
case object Yes extends Maybe
case object No extends Maybe
```

If we don't stop shrinking at some singleton, we will alternate endlessly between `Yes` and `No` until the stack overflows.

fixes #55