### PR TITLE
Ensure deriving Shrink instances isn't quadratic vs number of ADT cases

### DIFF
--- a/core/shared/src/main/scala/org/scalacheck/ScalacheckShapeless.scala
+++ b/core/shared/src/main/scala/org/scalacheck/ScalacheckShapeless.scala
@@ -5,7 +5,7 @@ import derive._
 trait ScalacheckShapeless
   extends SingletonInstances
   with HListInstances
-  with CoproductInstances
+  with CoproductInstances0
   with DerivedInstances
   with FieldTypeInstances
   with EnumerationInstances

--- a/core/shared/src/main/scala/org/scalacheck/derive/Instances.scala
+++ b/core/shared/src/main/scala/org/scalacheck/derive/Instances.scala
@@ -91,9 +91,19 @@ trait CoproductInstances {
    ): Cogen[C] =
     arb.cogen
 
-  implicit def coproductShrink[C <: Coproduct]
+  @deprecated("Kept for binary compatibility", "1.1.7")
+  def coproductShrink[C <: Coproduct]
    (implicit
      arb: MkCoproductShrink[C]
+   ): Shrink[C] =
+    arb.shrink
+}
+
+trait CoproductInstances0 extends CoproductInstances {
+
+  implicit def coproductShrink0[C <: Coproduct]
+   (implicit
+     arb: MkCoproductShrink0[C]
    ): Shrink[C] =
     arb.shrink
 }

--- a/test/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
+++ b/test/shared/src/test/scala/org/scalacheck/ShrinkTests.scala
@@ -35,21 +35,18 @@ object ShrinkTests extends TestSuite {
     )
 
   lazy val expectedIntStringBoolCoproductShrink =
-    MkCoproductShrink.ccons(
+    MkCoproductShrink0.ccons(
       Strict(Shrink.shrinkIntegral[Int]),
-      MkCoproductShrink.ccons(
+      MkCoproductShrink0.ccons(
         Strict(Shrink.shrinkString),
-        MkCoproductShrink.ccons(
+        MkCoproductShrink0.ccons(
           Strict(Shrink.shrinkAny[Boolean]),
-          MkCoproductShrink.cnil,
-          Strict(Singletons[Boolean]),
-          Strict(Singletons[CNil])
+          MkCoproductShrink0.cnil,
+          Strict(Singletons[Boolean])
         ),
-        Strict(Singletons[String]),
-        Strict(Singletons[Boolean :+: CNil])
+        Strict(Singletons[String])
       ),
-      Strict(Singletons[Int]),
-      Strict(Singletons[String :+: Boolean :+: CNil])
+      Strict(Singletons[Int])
     ).shrink
 
   lazy val expectedSimpleShrink =
@@ -70,16 +67,14 @@ object ShrinkTests extends TestSuite {
     ).shrink
 
   lazy val expectedUnionShrink =
-    MkCoproductShrink.ccons[FieldType[Witness.`'i`.T, Int], Union.`'s -> String`.T](
+    MkCoproductShrink0.ccons[FieldType[Witness.`'i`.T, Int], Union.`'s -> String`.T](
       shrinkFieldType[Witness.`'i`.T, Int](Shrink.shrinkIntegral[Int]),
-      MkCoproductShrink.ccons[FieldType[Witness.`'s`.T, String], CNil](
+      MkCoproductShrink0.ccons[FieldType[Witness.`'s`.T, String], CNil](
         shrinkFieldType[Witness.`'s`.T, String](Shrink.shrinkString),
-        MkCoproductShrink.cnil,
-        Singletons[FieldType[Witness.`'s`.T, String]],
-        Singletons[CNil]
+        MkCoproductShrink0.cnil,
+        Singletons[FieldType[Witness.`'s`.T, String]]
       ),
-      Singletons[FieldType[Witness.`'i`.T, Int]],
-      Singletons[Union.`'s -> String`.T]
+      Singletons[FieldType[Witness.`'i`.T, Int]]
     ).shrink
 
 


### PR DESCRIPTION
The lookup for `Singletons[T]` in `MkCoproductShrink.ccons` was making things quadratic.