### PR TITLE
check $TRAVIS_REPO_SLUG env before publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 jdk:
 - oraclejdk8
 script: sbt -batch ++${TRAVIS_SCALA_VERSION} test:compile testJVM/test mimaReportBinaryIssues $(if [[ "${TRAVIS_PULL_REQUEST}" ==
-  "false" && "${TRAVIS_BRANCH}" == "master" ]]; then echo "publish"; fi)
+  "false" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_REPO_SLUG}" == "alexarchambault/scalacheck-shapeless" ]]; then echo "publish"; fi)
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
I want to execute travis-ci job in my fork repository. but "publish" task fail

> TRAVIS_REPO_SLUG: The slug (in form: owner_name/repo_name) of the repository currently being built.

https://docs.travis-ci.com/user/environment-variables/