### PR TITLE
Adopt the Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,7 +13,10 @@ support you.
 
 ## Moderation
 
-For any questions, concerns, or moderation requests please contact a
-member of the project.
+For any questions, concerns, or moderation requests please contact
+[Alexandre Archambault], or
+[any of the moderators](https://typelevel.org/code-of-conduct.html#contact)
+of the [Scala Code of Conduct].
 
+[Alexandre Archambault]: mailto:alexandre.archambault+github@gmail.com
 [Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ without having to define yourself an `Arbitrary` for `Foo`.
 ## License
 
 Released under the Apache 2 license. See LICENSE file for more details.
+
+## Code of Conduct
+
+See the [Code of Conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Typelevel is [switching to the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html), and encouraging all member projects to adopt it.