### PR TITLE
Update install section to avoid scala 2.10 problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add to your `build.sbt`
 ```scala
 resolvers += Resolver.sonatypeRepo("releases") // only needed if the release hasn't reached maven central yet
 
-libraryDependencies += "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.0"
+libraryDependencies += "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.3"
 ```
 
 If you are using scala 2.10.x, also add the macro paradise plugin to your build,


### PR DESCRIPTION
`scalacheck-shapeless_1.14 % 1.2.0` releases do not exist for scala 2.10 or 2.11. There is only a `2.1.0-1` release. This means SBT is unable to resolve `"com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.0"` when using scala 2.10 or 2.11.

This commit ups the specified version from `1.2.0` to `1.2.3` so all scala versions can resolve properly. `1.2.3` exists for scala 2.10, 2.11, and 2.12